### PR TITLE
✨ Adds chartFrame.extends() to pass through custom properties

### DIFF
--- a/build/g-chartframe.js
+++ b/build/g-chartframe.js
@@ -44,11 +44,11 @@
         const sourcePosition = { x: 1 };
         const titlePosition = { x: 1, y: 30 };
         const transition = 0.2;
-
         const convertFrom = {
             mm(x) { return (x * 2.83464480558843); },
             px(x) { return x; },
         };
+        const custom = {};
 
         function attributeStyle(parent, style) {
             Object.keys(style).forEach((attribute) => {
@@ -203,7 +203,7 @@
                             if (sourcePosition.y) {
                                 return (sourcePosition.y + (i * sourceLineHeight));
                             }
-                            return (((graphicHeight - (margin.bottom - sourcePlotYOffset)) + (sourceLineHeight * 1.5)) + ((i) * sourceLineHeight));
+                            return ((graphicHeight - (margin.bottom - sourcePlotYOffset) + sourceLineHeight * 1.5) + ((i) * sourceLineHeight)); // eslint-disable-line
                         })
                         .attr('x', subtitlePosition.x)
                         .call(attributeStyle, subtitleStyle);
@@ -216,7 +216,7 @@
                     if (sourcePosition.y) {
                         return (sourcePosition.y + (i * sourceLineHeight));
                     }
-                    return (((graphicHeight - (margin.bottom - sourcePlotYOffset)) + (sourceLineHeight * 1.5)) + ((i) * sourceLineHeight));
+                    return ((graphicHeight - (margin.bottom - sourcePlotYOffset) + sourceLineHeight * 1.5) + ((i) * sourceLineHeight)); // eslint-disable-line
                 })
                 .attr('x', sourcePosition.x)
                 .call(attributeStyle, sourceStyle);
@@ -234,9 +234,9 @@
                     .attr('x', sourcePosition.x)
                     .attr('y', () => {
                         if (sourceLineCount > 1) {
-                            return ((graphicHeight - (margin.bottom - sourcePlotYOffset)) + (sourceLineHeight * 1.125) + (sourceLineCount * sourceLineHeight * 1.2));
+                            return (graphicHeight - (margin.bottom - sourcePlotYOffset) + (sourceLineHeight * 1.125) + (sourceLineCount * sourceLineHeight * 1.2)); // eslint-disable-line
                         }
-                        return ((graphicHeight - (margin.bottom - sourcePlotYOffset)) + (sourceLineHeight * 2.5));
+                        return (graphicHeight - (margin.bottom - sourcePlotYOffset) + (sourceLineHeight * 2.5)); // eslint-disable-line
                     })
 
 
@@ -248,7 +248,7 @@
             if (autoPosition && (containerClass === 'ft-printgraphic' || containerClass === 'ft-socialgraphic' || containerClass === 'ft-videographic')) {
                 margin.top = (titlePosition.y + (titleLineCount * titleLineHeight) + (subtitleLineCount * subtitleLineHeight) + (rem / 3));
             } else if (autoPosition) {
-                margin.top = ((titlePosition.y + (titleLineCount * titleLineHeight) + (subtitleLineCount * subtitleLineHeight) + 28) - plotAdjuster);
+                margin.top = (titlePosition.y + (titleLineCount * titleLineHeight) + (subtitleLineCount * subtitleLineHeight) + 28 - plotAdjuster); // eslint-disable-line
             }
 
             // watermark
@@ -324,6 +324,15 @@
             width: graphicWidth - (margin.left + margin.right),
             height: graphicHeight - (margin.top + margin.bottom),
         });
+
+        frame.extend = (key, value) => {
+            custom[key] = value;
+            frame[key] = (d) => {
+                if (d === undefined) return custom[key];
+                custom[key] = d;
+                return frame;
+            };
+        };
 
         frame.fullYear = (x) => {
             if (x === undefined) return fullYear;
@@ -501,7 +510,7 @@
 
         frame.attrs = (x) => {
             if (x === undefined) {
-                return {
+                return Object.assign({}, {
                     autoPosition,
                     // axisAlign, // @FIX This is undef?
                     containerClass,
@@ -532,7 +541,7 @@
                     watermarkOffset,
                     watermarkSize,
                     units,
-                };
+                }, custom);
             }
 
             Object.keys(x).forEach((setterName) => {

--- a/src/chartframe.js
+++ b/src/chartframe.js
@@ -38,11 +38,11 @@ function chartFrame(configObject) {
     const sourcePosition = { x: 1 };
     const titlePosition = { x: 1, y: 30 };
     const transition = 0.2;
-
     const convertFrom = {
         mm(x) { return (x * 2.83464480558843); },
         px(x) { return x; },
     };
+    const custom = {};
 
     function attributeStyle(parent, style) {
         Object.keys(style).forEach((attribute) => {
@@ -319,6 +319,15 @@ function chartFrame(configObject) {
         height: graphicHeight - (margin.top + margin.bottom),
     });
 
+    frame.extend = (key, value) => {
+        custom[key] = value;
+        frame[key] = (d) => {
+            if (d === undefined) return custom[key];
+            custom[key] = d;
+            return frame;
+        };
+    };
+
     frame.fullYear = (x) => {
         if (x === undefined) return fullYear;
         fullYear = x;
@@ -495,7 +504,7 @@ function chartFrame(configObject) {
 
     frame.attrs = (x) => {
         if (x === undefined) {
-            return {
+            return Object.assign({}, {
                 autoPosition,
                 // axisAlign, // @FIX This is undef?
                 containerClass,
@@ -526,7 +535,7 @@ function chartFrame(configObject) {
                 watermarkOffset,
                 watermarkSize,
                 units,
-            };
+            }, custom);
         }
 
         Object.keys(x).forEach((setterName) => {

--- a/test/chart-frametest.js
+++ b/test/chart-frametest.js
@@ -19,3 +19,19 @@ tape('chartFrame works outside browser', (test) => {
     test.equal(chartContainer.select('.chart-title tspan').text(), 'Title: A description of the charts purpose');
     test.end();
 });
+
+tape('chartFrame can be extended', (test) => {
+    const defaultFrame = chartFrame.frame();
+    defaultFrame.extend('llama', 'duck');
+
+    // Test getter
+    test.equal(defaultFrame.llama(), 'duck');
+
+    // Test setter
+    defaultFrame.llama('quack');
+    test.equal(defaultFrame.llama(), 'quack');
+
+    // Test attrs
+    test.equal(defaultFrame.attrs().llama, 'quack');
+    test.end();
+});


### PR DESCRIPTION
Fixes #33. N.b., this is branched from `linting`, so please merge #32 before this.

Use (taken from test/chart-frametest.js):

```js
tape('chartFrame can be extended', (test) => {
    const defaultFrame = chartFrame.frame();
    defaultFrame.extend('llama', 'duck');

    // Test getter
    test.equal(defaultFrame.llama(), 'duck');

    // Test setter
    defaultFrame.llama('quack');
    test.equal(defaultFrame.llama(), 'quack');

    // Test attrs
    test.equal(defaultFrame.attrs().llama, 'quack');
    test.end();
});
```